### PR TITLE
add set control signals to match node-serial PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,14 @@ SerialPort.prototype.proxy = function () {
 	return func;
 }
 
+SerialPort.prototype.set = function (options, callback) {
+	console.log("Setting ", options);
+	chrome.serial.setControlSignals(this.connectionId, options, function(result){
+		if(result) callback();
+		else callback(result);
+	});
+};
+
 function SerialPortList(callback) {
 	if (typeof chrome != "undefined" && chrome.serial) {
 		chrome.serial.getDevices(function(ports) {


### PR DESCRIPTION
Support for Chromes already implemented control signals, matching the fork Ive sent to node-serialport https://github.com/voodootikigod/node-serialport/issues/384