### PR TITLE
fixing serialport.list to match node-serialport

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,15 +156,29 @@ SerialPort.prototype.proxy = function () {
 function SerialPortList(callback) {
 	if (typeof chrome != "undefined" && chrome.serial) {
 		chrome.serial.getDevices(function(ports) {
-			var portObjects = Array(ports.length);
-			for (var i = 0; i < ports.length; i++) {
-				portObjects[i] = new SerialPort(ports[i].path, null, false);
+  
+			var list = [];
+			for(var i=0;i<ports.length;++i){
+				list.push(compat(ports[i]));
 			}
-			callback(null, portObjects);
+			callback(null, list);
+
 		});
 	} else {
 		callback("No access to serial ports. Try loading as a Chrome Application.", null);
 	}
+
+	function compat(deviceInfo){
+		return {
+			comName: deviceInfo.path,
+			manufacturer: deviceInfo.vendorId,
+			serialNumber: undefined,
+			pnpId: undefined,
+			vendorId: "0x" + (deviceInfo.vendorId||0).toString(16),
+			productId: "0x" + (deviceInfo.productId||0).toString(16)
+		};
+	}
+
 };
 
 // Convert string to ArrayBuffer

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function SerialPortList(callback) {
 	function compat(deviceInfo){
 		return {
 			comName: deviceInfo.path,
-			manufacturer: deviceInfo.vendorId,
+			manufacturer: deviceInfo.displayName,
 			serialNumber: undefined,
 			pnpId: undefined,
 			vendorId: "0x" + (deviceInfo.vendorId||0).toString(16),


### PR DESCRIPTION
this makes browser serialport match node-serialport's return value for list.

this fixes modules like watch-serial work in the browser which depend on device name
https://github.com/voodootikigod/node-serialport/blob/master/serialport.js#L497
