### PR TITLE
Fix double listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,11 +208,13 @@ SerialPort.prototype.onOpen = function (callback, openInfo) {
 
   this.emit('open', openInfo);
 
+  this._reader = this.proxy('onRead');
+
+  this.options.serial.onReceive.addListener(this._reader);
+
   if(typeof callback === 'function'){
     callback(chrome.runtime.lastError, openInfo);
   }
-
-  this.options.serial.onReceive.addListener(this.proxy('onRead'));
 };
 
 SerialPort.prototype.onRead = function (readInfo) {
@@ -274,6 +276,10 @@ SerialPort.prototype.onClose = function (callback, result) {
   this.emit('close');
 
   this.removeAllListeners();
+  if(this._reader){
+    this.options.serial.onReceive.removeListener(this._reader);
+    this._reader = null;
+  }
 
   if (typeof callback === 'function') {
     callback(chrome.runtime.lastError, result);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "jshint": "^2.5.11",
+    "lodash": "^3.6.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.6.0"


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where closing the serial port and reopening would double register the listener on chrome.serial.

#### Where should the reviewer start?
The failing test added in `test/serialport-basic.js` which was committed in a separate commit before the fix.

#### How should this be manually tested?
Run tests on just the commit that added the test to see a failing test and then with the fix to see it passing.

#### Any background context you want to provide?
Found this while trying to close and open a serialport multiple times and was getting double responses back.

#### What are the relevant tickets?
None.