### PR TITLE
Close connection during specific onReceiveError cases, fixes connectionId leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,9 +154,9 @@ function SerialPort(path, options, openImmediately, callback) {
         } else {
           self.emit('disconnect', err);
         }
-        self.connectionId = -1;
-        self.emit('close');
-        self.removeAllListeners();
+        if(self.connectionId >= 0){
+          self.close();
+        }
         break;
       case 'timeout':
         break;


### PR DESCRIPTION
According to Chrome's serial documentation, when `onReceiveError` is called the connection is only paused but not automatically closed. This fixes an edge case where the `connectionId` was being reset but the underlying connection was never closed, leading to a connection leak.