### PR TITLE
update deprecated API patterns in sync with serialport 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To Use
 Opening a serial port:
 
 ```js
-var SerialPort = require("browser-serialport").SerialPort
+var SerialPort = require("browser-serialport");
 var serialPort = new SerialPort("/dev/tty-usbserial1", {
   baudrate: 57600
 });
@@ -84,13 +84,14 @@ serialPort.on("open", function () {
 });
 ```
 
-You can also call the open function, in this case instanciate the serialport with an additional flag.
+You can also call the open function, in this case instantiate the serialport with an additional `autoOpen` property set to `false`.
 
 ```js
 var SerialPort = require("browser-serialport").SerialPort
 var serialPort = new SerialPort("/dev/tty-usbserial1", {
-  baudrate: 57600
-}, false); // this is the openImmediately flag [default is true]
+  baudrate: 57600,
+  autoOpen: false
+});
 
 serialPort.open(function (error) {
   if ( error ) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function convertOptions(options){
   return options;
 }
 
-function SerialPort(path, options, openImmediately, callback) {
+function SerialPort(path, options, callback) {
 
   EE.call(this);
 
@@ -59,7 +59,7 @@ function SerialPort(path, options, openImmediately, callback) {
 
   options = (typeof options !== 'function') && options || {};
 
-  openImmediately = (openImmediately === undefined || openImmediately === null) ? true : openImmediately;
+  var autoOpen = (options.autoOpen === undefined || options.autoOpen === null) ? true : options.autoOpen;
 
   callback = callback || function (err) {
     if (err) {
@@ -166,7 +166,7 @@ function SerialPort(path, options, openImmediately, callback) {
 
   this.path = path;
 
-  if (openImmediately) {
+  if (autoOpen) {
     process.nextTick(function () {
       self.open(callback);
     });
@@ -411,9 +411,8 @@ function toBuffer(ab) {
   return buffer;
 }
 
-module.exports = {
-  SerialPort: SerialPort,
-  list: SerialPortList,
-  buffer2ArrayBuffer: buffer2ArrayBuffer,
-  used: [] //TODO: Populate this somewhere.
-};
+SerialPort.buffer2ArrayBuffer = buffer2ArrayBuffer;
+SerialPort.list = SerialPortList;
+SerialPort.used = [];
+
+module.exports = SerialPort;

--- a/test/serialport-basic.js
+++ b/test/serialport-basic.js
@@ -6,7 +6,7 @@ var without = require('lodash/array/without');
 var expect = chai.expect;
 
 var MockedSerialPort = require('../');
-var SerialPort = MockedSerialPort.SerialPort;
+var SerialPort = MockedSerialPort;
 
 var options;
 


### PR DESCRIPTION
👋  Hello!

I'm opening this pull request to sync up some API differences that have occured between `browser-serialport` and `node-serialport`.

For some background on why it'd be great to keep them in sync:

@monteslu opened this rad pull request on one of my libraries: https://github.com/noopkat/avrgirl-arduino/pull/78

I would love to merge it, however my library uses the latest version of `node-serialport`, so this would call the wrong things in `browser-serialport` when it's packaged up for web use.

Thanks for this awesome library - this is really helpful to a lot of folks in the nodebots community 💓 
